### PR TITLE
feat(release): add release workflow, dependabot config, and docs

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,31 @@
+# .github/ — Claude Code Guidance
+
+## Overview
+
+This directory contains GitHub Actions workflows and Dependabot configuration for the job-root-cache composite actions.
+
+## Cleanup Workflow (`workflows/cleanup.yml`)
+
+A reusable workflow (`workflow_call`) that deletes the job setup cache for the current run. Called by consuming workflows after their jobs complete to clean up the `job-setup-cache-<run_id>-<os>` cache entry.
+
+- Runs with `if: always()` to ensure cleanup happens regardless of job success/failure
+- Requires `GH_TOKEN` (via `secrets.GITHUB_TOKEN`) and `GH_REPO` (via `github.repository`)
+- Cache key pattern: `job-setup-cache-${{ github.run_id }}-${{ runner.os }}`
+
+## Release Workflow (`workflows/release.yml`)
+
+Delegates to the reusable workflow in [`brianespinosa/release-action`](https://github.com/brianespinosa/release-action). All release logic (semver versioning via git-cliff, changelog generation, GitHub release creation, alias tag management, and Dependabot major version PR title rewriting) lives there.
+
+**Semver mapping** (handled by git-cliff via conventional commits):
+- `feat` → minor bump
+- `fix` → patch bump
+- `!` after type/scope (e.g. `feat(ci)!:`) or `BREAKING CHANGE` footer → major bump
+- `chore`, `ci`, `docs`, `style` → no bump
+
+**REQUIRED: All PRs must be merged via squash merge.** The reusable workflow rewrites Dependabot major-version PR titles from `fix(deps):` to `feat(deps)!:` — this only takes effect when squash merging (the PR title becomes the commit message).
+
+## Dependabot (`dependabot.yml`)
+
+- Targets `github-actions` ecosystem only
+- Single update entry with `fix(deps):` conventional commit prefix for all updates
+- Major version bumps get their PR title rewritten to `feat(deps)!:` by the release workflow

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "fix(deps):"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
+
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "daily"
+    rebase-strategy: "auto"
     commit-message:
-      prefix: "fix(deps):"
+      prefix: "fix"
+      include: "scope"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    uses: brianespinosa/release-action/.github/workflows/release-workflow.yml@v1
+    with:
+      trigger: ${{ github.event_name }}
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See `README.md` for repository overview and contents.
+
+## Requirements
+
+### Distributed Documentation Structure
+
+This repository **REQUIRES** distributed CLAUDE.md files throughout the directory tree. Each subdirectory with significant functionality must have its own CLAUDE.md file:
+
+- `.github/CLAUDE.md` - GitHub Actions workflow and Dependabot documentation
+
+**When adding new features or directories:**
+
+- Create separate CLAUDE.md files in relevant subdirectories
+- Do NOT expand this root CLAUDE.md file with detailed information
+- Keep this root file focused on high-level repository overview only
+- Distributed files keep context focused and only load relevant information when working in specific parts of the codebase
+
+**README.md vs CLAUDE.md distinction:**
+
+When a directory has a README.md, the CLAUDE.md should reference it. When a directory has both files:
+
+- **README.md** - User-facing documentation (what the component does, detailed explanations, setup instructions, architecture overview)
+- **CLAUDE.md** - Claude-specific development guidance (critical warnings, gotchas, common tasks with file:line references, testing patterns)
+- **Pattern**: CLAUDE.md should reference README.md for overview/details and focus only on what Claude needs to work safely and effectively
+
+### Documentation Maintenance
+
+When making code changes, you MUST proactively suggest updates to relevant documentation:
+
+- **CLAUDE.md files** - If you add/modify workflows, configuration files, or significant functionality, suggest updates to the relevant CLAUDE.md file in that directory
+  - Keep CLAUDE.md files concise (prefer pointers over content duplication)
+  - Avoid code snippets that will become outdated
+  - Use file:line references to point to authoritative sources
+  - Focus on high-level "what/why/how", not detailed descriptions
+- **README.md files** - If changes affect user-facing documentation or setup instructions, suggest updates to the relevant README.md file
+- **Proactive identification** - After completing code changes, explicitly check if documentation has become outdated and offer to update it
+
+Do not wait for the user to ask about documentation. Identify when your changes have made documentation stale and suggest specific updates.
+
+### Git Workflow
+
+All commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/) syntax:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
+
+**NEVER** commit with `--no-verify`. If a pre-commit hook fails, fix the underlying issue before committing. Bypassing hooks defeats the purpose of CI parity at commit time.
+
+**Commit message requirements:**
+
+- Keep messages brief and easy to parse - avoid lengthy descriptions
+- Focus on specific, scannable details that help humans quickly identify what a commit contains
+- **NEVER** add "Generated with Claude Code" or similar footers to commit messages
+- **NEVER** add "Co-Authored-By: Claude" or any co-author footers to commits
+
+**Pull request requirements:**
+
+- **NEVER** add "Co-Authored-By: Claude" or any co-author attribution to PR descriptions
+- **NEVER** add "Generated with Claude Code" or similar attribution to PRs
+- Keep PR descriptions focused on technical changes, testing, and references
+
+### File Operations and Repository Root
+
+**CRITICAL**: All file creation and modification operations MUST be relative to the git repository root.
+
+- Before creating files or directories, identify the repository root with `git rev-parse --show-toplevel`
+- NEVER create files outside the repository boundary - they will not be version controlled
+- Use `git status` to confirm new files will be tracked by git
+
+### Technical Review Standards
+
+Always fully evaluate the technical merits of questions and suggestions against relevant sources of truth and documentation.
+
+**Do NOT** use validating phrases like "you're absolutely right" or similar affirmations. Instead:
+
+- Verify claims against actual code, configuration files, and documentation
+- Challenge suggestions when they conflict with established patterns or best practices
+- Provide objective, evidence-based responses
+- Respectfully disagree when warranted, citing specific technical reasons
+
+Technical accuracy and honest assessment are more valuable than agreement.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ jobs:
       - uses: brianespinosa/job-root-cache/restore@main
       - run: yarn test
 
-  cleanup:
+  job-cache-cleanup:
     runs-on: ubuntu-latest
     needs: [lint, test]
     if: always()
     uses: brianespinosa/job-root-cache/.github/workflows/cleanup.yml@main
-    secrets: inherit
 ```
 
 ## Assumptions

--- a/README.md
+++ b/README.md
@@ -1,2 +1,59 @@
 # job-root-cache
-Composite actions that will save/read/remove a cache of the root directory to be used after clone and install.
+
+![Last Updated](https://img.shields.io/github/last-commit/brianespinosa/job-root-cache?label=Last%20Updated&cacheSeconds=120)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+Composite actions that save, restore, and clean up a cache of the root directory across jobs in a single workflow run. Avoids re-running checkout and install for every parallel job.
+
+- **`brianespinosa/job-root-cache/save`** — saves the current working directory to a run-scoped cache after checkout and install
+- **`brianespinosa/job-root-cache/restore`** — restores the cached directory and sets up the correct Node version from `.nvmrc`
+- **`brianespinosa/job-root-cache/cleanup`** (reusable workflow) — deletes the cache entry at the end of the workflow run
+
+## Usage
+
+```yaml ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: brianespinosa/checkout-setup-node-install@main
+      - uses: brianespinosa/job-root-cache/save@main
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: brianespinosa/job-root-cache/restore@main
+      - run: yarn lint
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: brianespinosa/job-root-cache/restore@main
+      - run: yarn test
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: always()
+    uses: brianespinosa/job-root-cache/.github/workflows/cleanup.yml@main
+    secrets: inherit
+```
+
+## Assumptions
+
+- A `.nvmrc` file is present in the repository root
+- `brianespinosa/checkout-setup-node-install` or an equivalent action is used in the setup job before saving the cache
+- All jobs in a workflow run use a single OS (cache key is scoped to `runner.os`)


### PR DESCRIPTION
## Summary

- Wires up `brianespinosa/release-action@v1` reusable workflow via `.github/workflows/release.yml`
- Adds `.github/dependabot.yml` for weekly github-actions updates with `fix(deps):` prefix
- Rewrites `README.md` with badges, component descriptions, save/restore/cleanup usage example, and assumptions
- Updates `.github/CLAUDE.md` to document the new release workflow and dependabot config

## Pre-work completed

- v1.0.0 baseline tag and GitHub release created manually (empty changelog — no conventional commits in history)
- Alias tags `v1` and `v1.0` pushed to origin
- Rebase merges disabled on repo

## Test plan

- [ ] Merge this PR via squash merge
- [ ] Confirm release workflow runs and skips (no version-bump-worthy commits since v1.0.0)
- [ ] Merge a `fix:` commit → confirm patch release created with `v1.0.1`, `v1`, `v1.0` alias tags updated
- [ ] Confirm Dependabot PR opens within a week with `fix(deps):` prefix