### PR TITLE
fix(deps): add dependabot entries for save and restore action dirs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,21 @@ updates:
     commit-message:
       prefix: "fix"
       include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/save"
+    schedule:
+      interval: "daily"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/restore"
+    schedule:
+      interval: "daily"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "fix"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Dependabot with `directory: "/"` only scans `.github/workflows/` — composite action files in subdirectories are not covered
- Adds separate `updates` entries for `/save` and `/restore` so Dependabot tracks `actions/cache/save`, `actions/cache/restore`, and `actions/setup-node` in those action files

## Test plan

- [ ] Merge via squash merge
- [ ] Confirm Dependabot opens PRs for outdated actions in `save/` and `restore/`