### PR TITLE
feat(config): add probot/settings config extending actions.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,21 @@ updates:
     commit-message:
       prefix: "fix"
       include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/save"
+    schedule:
+      interval: "daily"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/restore"
+    schedule:
+      interval: "daily"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "fix"
+      include: "scope"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+_extends: brianespinosa/settings:actions.yml
+
+repository:
+  name: job-root-cache
+  description: Composite actions that save, restore, and clean up a cache of the root directory across jobs in a single workflow run. Avoids re-running checkout and install for every parallel job.
+  topics: github-actions,composite-action,cache,nodejs,yarn
+  private: false


### PR DESCRIPTION
## Summary

- Adds `.github/settings.yml` wiring this repo into the shared [brianespinosa/settings](https://github.com/brianespinosa/settings) config via `_extends: brianespinosa/settings:actions.yml`
- Sets repo-specific fields: `name`, `description`, `topics`, `private`

## Test plan

- [ ] Merge and confirm probot/settings app applies config to this repo